### PR TITLE
Requirements updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-urbanaccess==0.2.0
-networkx==2.3
+urbanaccess==0.2.2
+networkx==2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 urbanaccess==0.2.2
-networkx==2.8
+networkx==2.8.6

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [r.strip() for r in requirements_lines]
 
 # now call setup
 setup(name='ua2nx',
-      version='0.0.4',
+      version='0.0.5',
       description='Converts UrbanAccess graph into NetworkX MultiDiGraph',
       long_description=long_description,
       url='https://github.com/htenkanen/ua2nx',


### PR DESCRIPTION
This is only a very small update to reflect the newest networkx and urbanaccess versions.
I did a local dev setup and ran the tests. Additionally, I tried it out on one of my projects and it works fine.
This way there are no dependency infringements with other packages and users are not required to downgrade their nx/ua.

One possibility would also be to not fix the version numbers of the two dependencies or switch the `==` to an `>=`.